### PR TITLE
Ensure that upgrade-installs show the "where do you want it installed" directory picker screen

### DIFF
--- a/Installer/installerScript.iss
+++ b/Installer/installerScript.iss
@@ -31,6 +31,11 @@ CloseApplicationsFilter=*.exe,*.dll,*.scr
 ; pick where the application installs to by default - {autopf} means c:\Program Files
 DefaultDirName={autopf}\Family Pic Screen Saver
 
+; Make the user pick the directory each time
+; (not because we're sadists, but without this the installer wizard doesn't show that page
+;  for upgrade installs. It's a "flow" thing)
+UsePreviousAppDir=no
+
 ; start menu folder name
 DefaultGroupName=Family Pic Screen Saver
 


### PR DESCRIPTION
Because the flow of the installer UX is weird when this screen is absent.